### PR TITLE
Fix for Dockerfile smell DL3025

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,25 +39,16 @@ EXPOSE 9000
 # The openssl command will generate self-signed certificate since some browsers like
 # Firefox and Chrome automatically do HTTPS requests. this will likely show a warning in
 # the browser, which you can ignore
-CMD ls -la /opt/gochan && ls -la && ls -la .. && sed -i /etc/gochan/gochan.json \
-	-e 's/"Port": 8080/"Port": 9000/' \
-	-e 's/"UseFastCGI": false/"UseFastCGI": true/' \
-	-e 's/"Username": ".*",//' \
-	-e 's#"DocumentRoot": "html"#"DocumentRoot": "/srv/gochan"#' \
-	-e 's#"TemplateDir": "templates"#"TemplateDir": "/usr/share/gochan/templates"#' \
-	-e 's#"LogDir": "log"#"LogDir": "/var/log/gochan"#' \
-	-e 's/"Verbosity": 0/"Verbosity": 1/' \
-	-e "s/\"DBtype\".*/\"DBtype\": \"${DBTYPE}\",/" \
-	-e "s/\"DBhost\".*/\"DBhost\": \"tcp(${DATABASE_HOST}:${DATABASE_PORT})\",/" \
-	-e "s/\"DBname\".*/\"DBname\": \"${DATABASE_NAME}\",/" \
-	-e "s/\"DBusername\".*/\"DBusername\": \"${DATABASE_USER}\",/" \
-	-e "s/\"DBpassword\".*/\"DBpassword\": \"${DATABASE_PASSWORD}\",/" \
-	&& mkdir -p /etc/ssl/private \
-	&& openssl req -x509 -nodes -days 7305 -newkey rsa:2048 -keyout /etc/ssl/private/nginx-selfsigned.key -out /etc/ssl/certs/nginx-selfsigned.crt -subj "/CN=127.0.0.1" \
-	&& ./build.py \
-	&& ./build.py install \
-	&& nginx \
-	&& echo "pinging db" \
-	&& docker/wait-for.sh $DATABASE_HOST:$DATABASE_PORT -t 30 \
-	&& /opt/gochan/gochan -rebuild all \
-	&& /opt/gochan/gochan
+CMD ["ls", "-la", "/opt/gochan", "&&", \
+     "ls", "-la", "&&", \
+     "ls", "-la", "..", "&&", \
+     "sed", "-i", "/etc/gochan/gochan.json", "-e", "s/\"Port\": 8080/\"Port\": 9000/", "-e", "s/\"UseFastCGI\": false/\"UseFastCGI\": true/", "-e", "s/\"Username\": \".*\",//", "-e", "s#\"DocumentRoot\": \"html\"#\"DocumentRoot\": \"/srv/gochan\"#", "-e", "s#\"TemplateDir\": \"templates\"#\"TemplateDir\": \"/usr/share/gochan/templates\"#", "-e", "s#\"LogDir\": \"log\"#\"LogDir\": \"/var/log/gochan\"#", "-e", "s/\"Verbosity\": 0/\"Verbosity\": 1/", "-e", "s/\"DBtype\".*/\"DBtype\": \"${DBTYPE}\",/", "-e", "s/\"DBhost\".*/\"DBhost\": \"tcp(${DATABASE_HOST}:${DATABASE_PORT})\",/", "-e", "s/\"DBname\".*/\"DBname\": \"${DATABASE_NAME}\",/", "-e", "s/\"DBusername\".*/\"DBusername\": \"${DATABASE_USER}\",/", "-e", "s/\"DBpassword\".*/\"DBpassword\": \"${DATABASE_PASSWORD}\",/", "&&", \
+     "mkdir", "-p", "/etc/ssl/private", "&&", \
+     "openssl", "req", "-x509", "-nodes", "-days", "7305", "-newkey", "rsa:2048", "-keyout", "/etc/ssl/private/nginx-selfsigned.key", "-out", "/etc/ssl/certs/nginx-selfsigned.crt", "-subj", "/CN=127.0.0.1", "&&", \
+     "./build.py", "&&", \
+     "./build.py", "install", "&&", \
+     "nginx", "&&", \
+     "echo", "pinging db", "&&", \
+     "docker/wait-for.sh", "$DATABASE_HOST:$DATABASE_PORT", "-t", "30", "&&", \
+     "/opt/gochan/gochan", "-rebuild", "all", "&&", \
+     "/opt/gochan/gochan"]


### PR DESCRIPTION
Hi!
The Dockerfile placed at "docker/Dockerfile" contains the best practice violation [DL3025](https://github.com/hadolint/hadolint/wiki/DL3025) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3025 occurs if the JSON notation is not used for the arguments of CMD and ENTRYPOINT instructions.
This pull request proposes a fix for that smell generated by my fixing tool. The patch was manually verified before opening the pull request. To fix this smell, specifically, the command arguments are refactored in the JSON notation format.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance
