### PR TITLE
Post hiding

### DIFF
--- a/frontend/ts/dom/posthiding.ts
+++ b/frontend/ts/dom/posthiding.ts
@@ -39,7 +39,7 @@ export function setPostVisibility(id: number|string, visibility: boolean, onComp
 		$backlink.text(id);
 		const newHidden = [];
 		for(const sID of hiddenStorage) {
-			if(sID !== id && newHidden.indexOf(sID) === -1) newHidden.push(sID);
+			if(sID !== String(id) && newHidden.indexOf(sID) === -1) newHidden.push(sID);
 		}
 		setStorageVal("hiddenposts", newHidden.join(","));
 	} else {


### PR DESCRIPTION
When I was testing posts hiding, I noticed that when a post is hidden and revealed, it remains hidden when the page reloads. I went to the source code to see what was wrong and saw that it should work a little differently, but I didn't understand what it was....
In the end I saw a bug when creating a new array for hidden posts, there is no type conversion, so the disclosed post stays in the new array and is still hidden when the page reloads. After fixing this small detail, the function started working as intended.